### PR TITLE
Update uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -25,7 +25,10 @@ rex_dir::deleteFiles(rex_path::media(), false);
 rex_file::put(rex_path::media('.redaxo'), "// Ordner für abgelegte Dateien von redaxo\n");
 
 // delete directory 'resources'
-rex_dir::delete(rex_path::base('resources'), true);
+if (!rex_dir::delete(rex_path::base('resources'), true) ) {
+    rex_logger::factory()->warning("AddOn: demo_base
+    Das Verzeichnis ".rex_path::base('resources')." konnte nicht gelöscht werden.");
+}
 
 // update config
 // remove additional config from base config


### PR DESCRIPTION
Versuch der Meldungsausgabe bei Fehlschlagen das Löschen eines Verzeichnisses zu protokollieren

Dies ist nur eine Idee/Überlegung!
Das Verzeichnis _resources_ wurde bei mir wegen fehlender Verzeichnisrechte nicht gelöscht. Es gibt bisher keine Fehlermeldung oder Hinweis im Systemlog darauf.
Dies soll nur die Möglichkeit aufzeigen, zumindest im Systemlog eine Nachricht dazu zu hinterlassen. Besser oder zusätzlich wäre ein Hinweis direkt bei der Addon-Ansicht. Bisher steht dort trotz des Fehlschlages "AddOn demo_base wurde deinstalliert!".

Es gibt noch diverse rex_file::delete. Wäre vielleicht da auch angebracht, bei Fehlern zumindest etwas ins Log zu schreiben.

Die Warnmeldung sieht bei mir so aus:
![grafik](https://github.com/FriendsOfREDAXO/demo_base/assets/330686/b7267d03-a2b9-44eb-bc70-9883e8989c09)
